### PR TITLE
Run script to verify tags in bash on Windows

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -37,6 +37,7 @@ jobs:
             echo "Tag version ($TAG_VERSION) does not match package.json version ($PACKAGE_VERSION)"
             exit 1
           fi
+        shell: bash
 
       - name: Build app
         run: npm run build


### PR DESCRIPTION
Please approve ASAP. Should fix build-and-release errors for Windows runner. The script that verifies the version in package.json matches the release tag was not being run in bash on Windows. 